### PR TITLE
Fix CorePersistence SeedData path

### DIFF
--- a/Modules/CorePersistence/Package.swift
+++ b/Modules/CorePersistence/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             ],
             path: "Sources",
             resources: [
-                .process("SeedData")
+                .process("CorePersistence/SeedData")
             ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency=complete"),


### PR DESCRIPTION
## Summary
- update CorePersistence target resource path

## Testing
- `bash ./Tools/linting/lint.sh` *(fails: SwiftFormat not found)*
- `swift test` in `Modules/CorePersistence` *(fails: package ../Domain missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856ee10b7a08320bd4d047e8228a042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the location of resource files used by the application. No visible changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->