### PR TITLE
Fix Domain package path references

### DIFF
--- a/Features/AnalyticsDashboard/Package.swift
+++ b/Features/AnalyticsDashboard/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../../Modules/CoreUI"),
-        .package(path: "../../Modules/Domain"),
+        .package(path: "../../PlatformAgnostic/Domain"),
         .package(path: "../../Modules/AnalyticsService"),
         .package(path: "../../Modules/FeatureInterfaces")
     ],

--- a/Features/Home/Package.swift
+++ b/Features/Home/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../../Modules/Domain"),
+        .package(path: "../../PlatformAgnostic/Domain"),
         .package(path: "../../Modules/CoreUI"),
         .package(path: "../../Modules/FeatureSupport"),
         .package(path: "../../Modules/FeatureInterfaces"),

--- a/Features/Planner/package.swift
+++ b/Features/Planner/package.swift
@@ -17,7 +17,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../../Modules/Domain"),
+        .package(path: "../../PlatformAgnostic/Domain"),
         .package(path: "../../Modules/CoreUI"),
         .package(path: "../../Modules/FeatureSupport"),
         .package(path: "../../Modules/CorePersistence")

--- a/Features/Profile/Package.swift
+++ b/Features/Profile/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // Internal packages
-        .package(path: "../../Modules/Domain"),
+        .package(path: "../../PlatformAgnostic/Domain"),
         .package(path: "../../Modules/CoreUI"),
         .package(path: "../../Modules/ServiceHealth"),
         // External image caching library

--- a/Features/WorkoutLogger/Package.swift
+++ b/Features/WorkoutLogger/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../../Modules/Domain"),
+        .package(path: "../../PlatformAgnostic/Domain"),
         .package(path: "../../Modules/CoreUI"),
         .package(path: "../../Modules/ServiceHealth"),
         .package(path: "../../Modules/AnalyticsService"),

--- a/Modules/AnalyticsService/Package.swift
+++ b/Modules/AnalyticsService/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
         // Local workspace packages
-        .package(path: "../Domain"),
+        .package(path: "../../PlatformAgnostic/Domain"),
         .package(path: "../CorePersistence")
     ],
     targets: [

--- a/Modules/CoreNetworking/Package.swift
+++ b/Modules/CoreNetworking/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // Internal model layer
-        .package(path: "../Domain"),
+        .package(path: "../../PlatformAgnostic/Domain"),
         // Combine helpers for reactive pipelines
         .package(url: "https://github.com/CombineCommunity/CombineExt.git", from: "1.5.0")
     ],

--- a/Modules/CorePersistence/Package.swift
+++ b/Modules/CorePersistence/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Internal domain schema
-        .package(path: "../Domain")
+        .package(path: "../../PlatformAgnostic/Domain")
         // External option: GRDB for server-side SQLite (disabled by default)
         // .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.5.0")
     ],

--- a/Modules/FeatureInterfaces/package.swift
+++ b/Modules/FeatureInterfaces/package.swift
@@ -19,7 +19,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../Domain")
+        .package(path: "../../PlatformAgnostic/Domain")
     ],
     targets: [
         .target(

--- a/Modules/FeatureSupport/Package.swift
+++ b/Modules/FeatureSupport/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../Domain"),
+        .package(path: "../../PlatformAgnostic/Domain"),
         .package(path: "../CoreUI"),
         .package(path: "../ServiceHealth"),
         .package(path: "../AnalyticsService")

--- a/Modules/ServiceHealth/package.swift
+++ b/Modules/ServiceHealth/package.swift
@@ -19,7 +19,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../Domain"),
+        .package(path: "../../PlatformAgnostic/Domain"),
         .package(path: "../CorePersistence")
     ],
     targets: [


### PR DESCRIPTION
## Summary
- fix relative paths to Domain across modules
- update feature packages to match new Domain location

## Testing
- `swift package resolve` in CoreNetworking
- `swift build -c debug` *(fails: no such module 'Darwin' when building CombineExt)*

------
https://chatgpt.com/codex/tasks/task_e_6856ee751d4483208df5cf6b58d1d51c