### PR TITLE
Add sync database helpers

### DIFF
--- a/Modules/CorePersistence/Sources/CorePersistence/DatabaseManager.swift
+++ b/Modules/CorePersistence/Sources/CorePersistence/DatabaseManager.swift
@@ -171,3 +171,208 @@ private extension Exercise {
         self.init(entity: managedObject)
     }
 }
+
+// MARK: - Synchronous API used in tests
+
+extension DatabaseManager {
+    /// Seed bundled exercise data using a custom bundle if the database is empty.
+    /// - Parameter bundle: Bundle containing the `exercises.json` resource.
+    public func seedInitialDataIfNeeded(bundle: Bundle) throws {
+        if try exerciseCount() > 0 { return }
+        guard let url = bundle.url(forResource: "exercises", withExtension: "json") else {
+            throw NSError(domain: "DatabaseManager", code: 1, userInfo: [NSLocalizedDescriptionKey: "Seed file missing"])
+        }
+        let data = try Data(contentsOf: url)
+        let library = try decoder.decode([Exercise].self, from: data)
+        for exercise in library {
+            try saveExercise(exercise)
+        }
+    }
+
+    /// Current number of Exercise records in the store.
+    public func exerciseCount() throws -> Int {
+        try backgroundContext.performAndWait {
+            let request: NSFetchRequest<ExerciseEntity> = ExerciseEntity.fetchRequest()
+            return try backgroundContext.count(for: request)
+        }
+    }
+
+    /// Persist or update a single `Exercise`.
+    public func saveExercise(_ exercise: Exercise) throws {
+        try backgroundContext.performAndWait {
+            let request: NSFetchRequest<ExerciseEntity> = ExerciseEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", exercise.id as CVarArg)
+            let entity = try backgroundContext.fetch(request).first ?? ExerciseEntity(context: backgroundContext)
+            entity.id = exercise.id
+            entity.name = exercise.name
+            entity.primaryMuscles = exercise.primaryMuscles.map { $0.rawValue }
+            entity.secondaryMuscles = exercise.secondaryMuscles.map { $0.rawValue }
+            entity.mechanicalPattern = exercise.mechanicalPattern.rawValue
+            entity.equipment = exercise.equipment.rawValue
+            entity.isUnilateral = exercise.isUnilateral
+            try backgroundContext.saveIfNeeded()
+        }
+    }
+
+    /// Fetch a single exercise by identifier.
+    public func fetchExercise(id: UUID) throws -> Exercise? {
+        try backgroundContext.performAndWait {
+            let request: NSFetchRequest<ExerciseEntity> = ExerciseEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+            request.fetchLimit = 1
+            guard let entity = try backgroundContext.fetch(request).first else { return nil }
+            return Exercise(entity: entity)
+        }
+    }
+
+    /// Remove an exercise by identifier.
+    public func deleteExercise(id: UUID) throws {
+        try backgroundContext.performAndWait {
+            let request: NSFetchRequest<ExerciseEntity> = ExerciseEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+            request.fetchLimit = 1
+            if let entity = try backgroundContext.fetch(request).first {
+                backgroundContext.delete(entity)
+                try backgroundContext.saveIfNeeded()
+            }
+        }
+    }
+
+    // MARK: Workout Sessions
+
+    /// Persist a complete workout session and its child objects.
+    public func saveWorkoutSession(_ session: WorkoutSession) throws {
+        try backgroundContext.performAndWait {
+            let request: NSFetchRequest<WorkoutSessionEntity> = WorkoutSessionEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", session.id as CVarArg)
+            let sessionEntity = try backgroundContext.fetch(request).first ?? WorkoutSessionEntity(context: backgroundContext)
+            sessionEntity.id = session.id
+            sessionEntity.date = session.date
+            sessionEntity.startTime = session.startTime
+            sessionEntity.endTime = session.endTime
+            sessionEntity.notes = session.notes
+            sessionEntity.planId = session.planId
+
+            // Remove existing logs before re-inserting to keep things simple.
+            if let existingLogs = sessionEntity.exerciseLogs as? Set<ExerciseLogEntity> {
+                for log in existingLogs { backgroundContext.delete(log) }
+            }
+
+            for log in session.exerciseLogs {
+                let logEntity = ExerciseLogEntity(context: backgroundContext)
+                logEntity.id = log.id
+                logEntity.exerciseId = log.exerciseId
+                logEntity.startTime = log.startTime
+                logEntity.endTime = log.endTime
+                logEntity.perceivedExertion = log.perceivedExertion as NSNumber?
+                logEntity.notes = log.notes
+                logEntity.session = sessionEntity
+
+                for set in log.performedSets {
+                    let setEntity = SetRecordEntity(context: backgroundContext)
+                    setEntity.id = set.id
+                    setEntity.weight = set.weight
+                    setEntity.reps = Int16(set.reps)
+                    setEntity.rir = set.rir as NSNumber?
+                    setEntity.rpe = set.rpe?.rawValue as NSNumber?
+                    setEntity.tempo = set.tempo
+                    setEntity.log = logEntity
+                }
+            }
+
+            try backgroundContext.saveIfNeeded()
+        }
+    }
+
+    /// Fetch a workout session by identifier.
+    public func fetchWorkoutSession(id: UUID) throws -> WorkoutSession? {
+        try backgroundContext.performAndWait {
+            let request: NSFetchRequest<WorkoutSessionEntity> = WorkoutSessionEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+            request.fetchLimit = 1
+            guard let entity = try backgroundContext.fetch(request).first else { return nil }
+            return WorkoutSession(entity: entity)
+        }
+    }
+
+    /// Delete a workout session and its children.
+    public func deleteWorkoutSession(id: UUID) throws {
+        try backgroundContext.performAndWait {
+            let request: NSFetchRequest<WorkoutSessionEntity> = WorkoutSessionEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+            request.fetchLimit = 1
+            if let entity = try backgroundContext.fetch(request).first {
+                backgroundContext.delete(entity)
+                try backgroundContext.saveIfNeeded()
+            }
+        }
+    }
+
+    /// Fetch a single exercise log.
+    public func fetchExerciseLog(id: UUID) throws -> ExerciseLog? {
+        try backgroundContext.performAndWait {
+            let request: NSFetchRequest<ExerciseLogEntity> = ExerciseLogEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+            request.fetchLimit = 1
+            guard let entity = try backgroundContext.fetch(request).first else { return nil }
+            return ExerciseLog(entity: entity)
+        }
+    }
+}
+
+// MARK: - Entity Mappers
+
+private extension WorkoutSession {
+    init?(entity: WorkoutSessionEntity) {
+        guard
+            let id = entity.id,
+            let date = entity.date,
+            let startTime = entity.startTime,
+            let logs = entity.exerciseLogs as? Set<ExerciseLogEntity>
+        else { return nil }
+
+        let mappedLogs = logs.compactMap(ExerciseLog.init(entity:))
+        self.init(id: id,
+                  date: date,
+                  exerciseLogs: mappedLogs.sorted { $0.startTime < $1.startTime },
+                  startTime: startTime,
+                  endTime: entity.endTime,
+                  notes: entity.notes,
+                  planId: entity.planId)
+    }
+}
+
+private extension ExerciseLog {
+    init?(entity: ExerciseLogEntity) {
+        guard
+            let id = entity.id,
+            let exerciseId = entity.exerciseId,
+            let sets = entity.sets as? Set<SetRecordEntity>,
+            let start = entity.startTime
+        else { return nil }
+
+        let mappedSets = sets.compactMap(SetRecord.init(entity:))
+        self.init(id: id,
+                  exerciseId: exerciseId,
+                  performedSets: mappedSets.sorted { $0.weight < $1.weight },
+                  perceivedExertion: entity.perceivedExertion as? Int,
+                  notes: entity.notes,
+                  startTime: start,
+                  endTime: entity.endTime)
+    }
+}
+
+private extension SetRecord {
+    init?(entity: SetRecordEntity) {
+        guard
+            let id = entity.id
+        else { return nil }
+
+        self.init(id: id,
+                  weight: entity.weight,
+                  reps: Int(entity.reps),
+                  rir: entity.rir as? Int,
+                  rpe: entity.rpe.flatMap { RPE(rawValue: $0.intValue) },
+                  tempo: entity.tempo)
+    }
+}


### PR DESCRIPTION
## Summary
- add synchronous CRUD helpers for unit tests
- support workout sessions and logs

## Testing
- `swift test` *(fails: package dependency path not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ee12d9d083208c59c88e9f83a471