### PR TITLE
Add Core Data model with ExerciseEntity

### DIFF
--- a/Modules/CorePersistence/Package.swift
+++ b/Modules/CorePersistence/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Internal domain schema
-        .package(path: "../Domain")
+        .package(path: "../../PlatformAgnostic/Domain")
         // External option: GRDB for server-side SQLite (disabled by default)
         // .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.5.0")
     ],
@@ -32,7 +32,8 @@ let package = Package(
             ],
             path: "Sources",
             resources: [
-                .process("SeedData")
+                .process("CorePersistence/SeedData"),
+                .process("CorePersistence/Model/GainzModel.xcdatamodeld")
             ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency=complete"),

--- a/Modules/CorePersistence/Sources/CorePersistence/DatabaseManager.swift
+++ b/Modules/CorePersistence/Sources/CorePersistence/DatabaseManager.swift
@@ -73,9 +73,11 @@ public final class DatabaseManager: DatabaseManaging {
             // Update the entity's fields with the latest data.
             entity.id = exercise.id
             entity.name = exercise.name
-            entity.primaryMuscles = exercise.primaryMuscles.map { $0.rawValue }  // store as array of raw strings
-            entity.mechanicalPattern = exercise.mechanicalPattern.rawValue      // store enum as raw value
-            // (Note: Any other properties like secondaryMuscles, equipment, etc., would be set here if present in domain model.)
+            entity.primaryMuscles = exercise.primaryMuscles.map { $0.rawValue }
+            entity.secondaryMuscles = exercise.secondaryMuscles.map { $0.rawValue }
+            entity.mechanicalPattern = exercise.mechanicalPattern.rawValue
+            entity.equipment = exercise.equipment.rawValue
+            entity.isUnilateral = exercise.isUnilateral
 
             // Save changes if any fields were modified.
             try backgroundContext.saveIfNeeded()
@@ -152,16 +154,28 @@ private extension Exercise {
             let id = entity.id,
             let name = entity.name,
             let primaryRaw = entity.primaryMuscles as? [String],
+            let secondaryRaw = entity.secondaryMuscles as? [String],
             let mechRaw = entity.mechanicalPattern,
-            let mech = MechanicalPattern(rawValue: mechRaw)
+            let equipRaw = entity.equipment,
+            let mech = MechanicalPattern(rawValue: mechRaw),
+            let equip = Equipment(rawValue: equipRaw)
         else {
             return nil  // Abort if any field is missing or if mechanicalPattern is unrecognized
         }
 
-        // Map primaryRaw [String] to [MuscleGroup] enum values.
-        let primaryMuscles = primaryRaw.compactMap(MuscleGroup.init(rawValue:))
-        // Initialize the Exercise struct with these values.
-        self.init(id: id, name: name, primaryMuscles: primaryMuscles, mechanicalPattern: mech)
+        // Map string arrays to enum sets.
+        let primaryMuscles = Set(primaryRaw.compactMap(MuscleGroup.init(rawValue:)))
+        let secondaryMuscles = Set(secondaryRaw.compactMap(MuscleGroup.init(rawValue:)))
+
+        self.init(
+            id: id,
+            name: name,
+            primaryMuscles: primaryMuscles,
+            secondaryMuscles: secondaryMuscles,
+            mechanicalPattern: mech,
+            equipment: equip,
+            isUnilateral: entity.isUnilateral
+        )
     }
 }
 

--- a/Modules/CorePersistence/Sources/CorePersistence/ExerciseEntity+CoreDataClass.swift
+++ b/Modules/CorePersistence/Sources/CorePersistence/ExerciseEntity+CoreDataClass.swift
@@ -1,0 +1,14 @@
+//  ExerciseEntity+CoreDataClass.swift
+//  CorePersistence
+//
+//  Managed object subclass for ExerciseEntity.
+//  Created for Gainz on 27 May 2025.
+//
+
+import Foundation
+import CoreData
+
+@objc(ExerciseEntity)
+public class ExerciseEntity: NSManagedObject {
+}
+

--- a/Modules/CorePersistence/Sources/CorePersistence/ExerciseEntity+CoreDataProperties.swift
+++ b/Modules/CorePersistence/Sources/CorePersistence/ExerciseEntity+CoreDataProperties.swift
@@ -1,0 +1,26 @@
+//  ExerciseEntity+CoreDataProperties.swift
+//  CorePersistence
+//
+//  Generated accessors for ExerciseEntity attributes.
+//  Created for Gainz on 27 May 2025.
+//
+
+import Foundation
+import CoreData
+
+extension ExerciseEntity {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ExerciseEntity> {
+        return NSFetchRequest<ExerciseEntity>(entityName: "ExerciseEntity")
+    }
+
+    @NSManaged public var id: UUID?
+    @NSManaged public var name: String?
+    @NSManaged public var primaryMuscles: [String]?
+    @NSManaged public var secondaryMuscles: [String]?
+    @NSManaged public var mechanicalPattern: String?
+    @NSManaged public var equipment: String?
+    @NSManaged public var isUnilateral: Bool
+}
+
+extension ExerciseEntity : Identifiable {}
+

--- a/Modules/CorePersistence/Sources/CorePersistence/Model/GainzModel.xcdatamodeld/.xccurrentversion
+++ b/Modules/CorePersistence/Sources/CorePersistence/Model/GainzModel.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>_XCCurrentVersionName</key>
+    <string>GainzModel.xcdatamodel</string>
+</dict>
+</plist>

--- a/Modules/CorePersistence/Sources/CorePersistence/Model/GainzModel.xcdatamodeld/GainzModel.xcdatamodel/contents
+++ b/Modules/CorePersistence/Sources/CorePersistence/Model/GainzModel.xcdatamodeld/GainzModel.xcdatamodel/contents
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22483" systemVersion="23A2049" minimumToolsVersion="Automatic" sourceLanguage="Swift">
+    <entity name="ExerciseEntity" representedClassName="ExerciseEntity" syncable="YES">
+        <attribute name="id" attributeType="UUID" optional="NO"/>
+        <attribute name="name" attributeType="String" optional="NO"/>
+        <attribute name="primaryMuscles" attributeType="Transformable" attributeValueClassName="NSArray" optional="NO"/>
+        <attribute name="secondaryMuscles" attributeType="Transformable" attributeValueClassName="NSArray" optional="NO"/>
+        <attribute name="mechanicalPattern" attributeType="String" optional="NO"/>
+        <attribute name="equipment" attributeType="String" optional="NO"/>
+        <attribute name="isUnilateral" attributeType="Boolean" optional="NO"/>
+    </entity>
+</model>


### PR DESCRIPTION
## Summary
- introduce `GainzModel.xcdatamodeld` with `ExerciseEntity`
- provide `ExerciseEntity` managed object subclasses
- wire model resources into CorePersistence package
- persist all exercise fields in `DatabaseManager`
- fix CorePersistence Package.swift paths

## Testing
- `swift build` *(fails: no such module 'CoreData')*

------
https://chatgpt.com/codex/tasks/task_e_6856ee11dad88320bad84ea2304b575d