### PR TITLE
Fix FeatureInterfaces build issues

### DIFF
--- a/Modules/FeatureInterfaces/Sources/FeatureInterfaces/FeatureEntryPlanner.swift
+++ b/Modules/FeatureInterfaces/Sources/FeatureInterfaces/FeatureEntryPlanner.swift
@@ -9,27 +9,6 @@
 
 import Foundation
 
-/// Minimal router contract used by tests.
-public protocol NavigationRouting {
-    func push(_ route: FeatureRoute, animated: Bool)
-}
-
-/// Simple enum representing app feature destinations.
-public struct FeatureRoute: Hashable {
-    public enum Kind {
-        case workoutLogger
-        // Other cases omitted for brevity
-    }
-
-    public var kind: Kind
-    public var payload: [String: Any] = [:]
-
-    public init(kind: Kind, payload: [String: Any] = [:]) {
-        self.kind = kind
-        self.payload = payload
-    }
-}
-
 /// Convenience wrapper used in tests to drive navigation to the
 /// Workout Logger from the Planner card.
 public struct FeatureEntryPlanner {

--- a/Modules/FeatureInterfaces/Tests/FeatureInterfacesTests.swift
+++ b/Modules/FeatureInterfaces/Tests/FeatureInterfacesTests.swift
@@ -35,7 +35,7 @@ final class FeatureInterfacesTests: XCTestCase {
             let payload = ["foo": "bar"]
 
             // When – encode ➜ URL
-            let url = try kind.makeURL(payload: payload)
+            let url = FeatureRoute(kind: kind, payload: payload).url()
 
             // Then – decode ➜ route
             let route = try FeatureRoute(url: url)
@@ -77,31 +77,3 @@ private struct MockNavigationRouter: NavigationRouting {
     }
 }
 
-// MARK: – Helpers (guard compile-time failures only)
-
-/// Extend FeatureKind with a minimal fixture API expected in tests.
-private extension FeatureKind {
-    /// Example identifier string for deep-link matching.
-    var identifier: String {
-        switch self {
-        case .home:           return "home"
-        case .planner:        return "planner"
-        case .workoutLogger:  return "workout_logger"
-        case .analytics:      return "analytics"
-        case .profile:        return "profile"
-        case .settings:       return "settings"
-        }
-    }
-
-    /// Serialises a payload into a deep-link URL.
-    func makeURL(payload: [String: Any]) throws -> URL {
-        var components       = URLComponents()
-        components.scheme     = "gainz"
-        components.host       = identifier
-        components.queryItems = payload.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
-        guard let url = components.url else {
-            throw URLError(.badURL)
-        }
-        return url
-    }
-}


### PR DESCRIPTION
## Summary
- remove duplicate protocol and struct definitions
- update tests to use new `FeatureRoute.url()` API

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6856f024a92083209ed5d3627a039c70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed routing abstractions, including the navigation protocol and route struct, from the interface layer.
  - Updated tests to construct deep-link URLs directly from route instances.
- **Tests**
  - Modified deep-link URL tests to use a new approach for URL creation.
- **Chores**
  - Cleaned up unused private extensions related to deep-link URL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->